### PR TITLE
Support multiple codes in the follow-up

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
     # TODO: Report percentages?
     # TODO: Handle distributions for other variables too or just demographics?
     demographic_distributions = OrderedDict()  # of analysis_file_key -> code string_value -> number of individuals
-    for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
+    for plan in PipelineConfiguration.DEMOG_CODING_PLANS:
         for cc in plan.coding_configurations:
             if cc.analysis_file_key is None:
                 continue
@@ -189,7 +189,7 @@ if __name__ == "__main__":
         if ind["consent_withdrawn"] == Codes.TRUE:
             continue
 
-        for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
+        for plan in PipelineConfiguration.DEMOG_CODING_PLANS:
             for cc in plan.coding_configurations:
                 if cc.analysis_file_key is None:
                     continue

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -82,7 +82,7 @@ def get_rqa_coding_plans(pipeline_name):
     ]
 
 
-def get_survey_coding_plans(pipeline_name):
+def get_demog_coding_plans(pipeline_name):
     return [
         CodingPlan(raw_field="operator_raw",
                    coding_configurations=[
@@ -228,8 +228,12 @@ def get_survey_coding_plans(pipeline_name):
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("household language"),
-                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal)
+    ]
 
+
+def get_follow_up_coding_plans(survey_name):
+    return [
         CodingPlan(raw_field="government_priority_raw",
                    time_field="government_priority_time",
                    coda_filename="government_priority.json",

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -235,16 +235,16 @@ def get_survey_coding_plans(pipeline_name):
                    coda_filename="government_priority.json",
                    coding_configurations=[
                        CodingConfiguration(
-                           coding_mode=CodingModes.SINGLE,
+                           coding_mode=CodingModes.MULTIPLE,
                            code_scheme=CodeSchemes.GOVERNMENT_PRIORITY,
                            cleaner=None,
                            coded_field="government_priority_coded",
                            analysis_file_key="government_priority",
-                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.GOVERNMENT_PRIORITY, x, y)
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("s07 government priority"),
-                   raw_field_fold_strategy=FoldStrategies.assert_equal)
+                   raw_field_fold_strategy=FoldStrategies.concatenate)
     ]
 
 

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -60,12 +60,12 @@ class PipelineConfiguration(object):
         self.data_archive_upload_url_prefix = data_archive_upload_url_prefix
 
         PipelineConfiguration.RQA_CODING_PLANS = coding_plans.get_rqa_coding_plans(self.pipeline_name)
-        PipelineConfiguration.SURVEY_CODING_PLANS = coding_plans.get_survey_coding_plans(self.pipeline_name)
 
-        # TODO: This is a temporary hack to extract demographics out of the surveys, so that the
-        #       automated analysis can analyse demographics only. Not fixing this properly here for now, because we may
-        #       instead decide to analysis all of the survey questions in the same way as we do the demographics.
-        PipelineConfiguration.DEMOG_CODING_PLANS = coding_plans.get_survey_coding_plans(self.pipeline_name)[0:5]
+        PipelineConfiguration.DEMOG_CODING_PLANS = coding_plans.get_demog_coding_plans(self.pipeline_name)
+        PipelineConfiguration.FOLLOW_UP_CODING_PLANS = coding_plans.get_follow_up_coding_plans(self.pipeline_name)
+        PipelineConfiguration.SURVEY_CODING_PLANS = \
+            PipelineConfiguration.DEMOG_CODING_PLANS + PipelineConfiguration.FOLLOW_UP_CODING_PLANS
+
         PipelineConfiguration.WS_CORRECT_DATASET_SCHEME = coding_plans.get_ws_correct_dataset_scheme(self.pipeline_name)
 
         self.validate()


### PR DESCRIPTION
Handled in analysis by not including the follow-ups in demographic_distributions.csv (it doesn't really make sense to include things other than demographics in 'demographic_distributions' anyway). 

Also tidies up where the follow-ups are declared, by separating surveys into demographics and follow-ups in configuration.