### PR TITLE
Remove explicit trailing underscore in analysis_key when coding mode is MULTIPLE

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -288,7 +288,7 @@ if __name__ == "__main__":
             for code in cc.code_scheme.codes:
                 if code.control_code == Codes.STOP:
                     continue
-                themes[f"{cc.analysis_file_key}{code.string_value}"] = make_survey_counts_dict()
+                themes[f"{cc.analysis_file_key}_{code.string_value}"] = make_survey_counts_dict()
 
         # Fill in the counts by iterating over every individual
         for td in individuals:
@@ -302,8 +302,8 @@ if __name__ == "__main__":
                     code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
                     if code.control_code == Codes.STOP:
                         continue
-                    themes[f"{cc.analysis_file_key}{code.string_value}"]["Total Participants"] += 1
-                    update_survey_counts(themes[f"{cc.analysis_file_key}{code.string_value}"], td)
+                    themes[f"{cc.analysis_file_key}_{code.string_value}"]["Total Participants"] += 1
+                    update_survey_counts(themes[f"{cc.analysis_file_key}_{code.string_value}"], td)
                     if code.code_type == CodeTypes.NORMAL:
                         relevant_participant = True
 
@@ -320,7 +320,7 @@ if __name__ == "__main__":
                     if code.code_type != CodeTypes.NORMAL:
                         continue
 
-                    theme = themes[f"{cc.analysis_file_key}{code.string_value}"]
+                    theme = themes[f"{cc.analysis_file_key}_{code.string_value}"]
                     set_survey_percentages(theme, themes["Total Relevant Participants"])
 
     with open(f"{output_dir}/theme_distributions.csv", "w") as f:
@@ -418,7 +418,7 @@ if __name__ == "__main__":
                 if code.code_type != CodeTypes.NORMAL:
                     continue
 
-                theme = f"{cc.analysis_file_key}{code.string_value}"
+                theme = f"{cc.analysis_file_key}_{code.string_value}"
                 log.info(f"Generating a map of per-region participation for {theme}...")
                 demographic_counts = episode[theme]
 
@@ -475,7 +475,7 @@ if __name__ == "__main__":
                 if code.code_type != CodeTypes.NORMAL:
                     continue
 
-                theme = f"{cc.analysis_file_key}{code.string_value}"
+                theme = f"{cc.analysis_file_key}_{code.string_value}"
                 log.info(f"Generating a map of per-district participation for {theme}...")
                 demographic_counts = episode[theme]
 
@@ -534,7 +534,7 @@ if __name__ == "__main__":
                 if code.code_type != CodeTypes.NORMAL:
                     continue
 
-                theme = f"{cc.analysis_file_key}{code.string_value}"
+                theme = f"{cc.analysis_file_key}_{code.string_value}"
                 log.info(f"Generating a map of Mogadishu participation for {theme}...")
                 demographic_counts = episode[theme]
 
@@ -607,7 +607,7 @@ if __name__ == "__main__":
                 assert cc.coding_mode == CodingModes.MULTIPLE
                 for ind in individuals:
                     for code in cc.code_scheme.codes:
-                        if ind[f"{cc.analysis_file_key}{code.string_value}"] == Codes.MATRIX_1:
+                        if ind[f"{cc.analysis_file_key}_{code.string_value}"] == Codes.MATRIX_1:
                             label_counts[code.string_value] += 1
 
             data = [{"Label": k, "Number of Participants": v} for k, v in label_counts.items()]
@@ -643,7 +643,7 @@ if __name__ == "__main__":
         for cc in plan.coding_configurations:
             for code in cc.code_scheme.codes:
                 if code.code_type == CodeTypes.NORMAL and code.string_value not in {"knowledge", "attitude", "behaviour"}:
-                    normal_themes[code.string_value] = episode[f"{cc.analysis_file_key}{code.string_value}"]
+                    normal_themes[code.string_value] = episode[f"{cc.analysis_file_key}_{code.string_value}"]
 
         if len(normal_themes) == 0:
             log.warning(f"Skipping graphing normal themes by gender for {plan.raw_field} because the scheme does "

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -39,7 +39,7 @@ def get_rqa_coding_plans(pipeline_name):
                            coding_mode=CodingModes.MULTIPLE,
                            code_scheme=CodeSchemes.S07E01,
                            coded_field="rqa_s07e01_coded",
-                           analysis_file_key="rqa_s07e01_",
+                           analysis_file_key="rqa_s07e01",
                            fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.S07E01, x, y)
                        )
                    ],
@@ -56,7 +56,7 @@ def get_rqa_coding_plans(pipeline_name):
                            coding_mode=CodingModes.MULTIPLE,
                            code_scheme=CodeSchemes.S07E02,
                            coded_field="rqa_s07e02_coded",
-                           analysis_file_key="rqa_s07e02_",
+                           analysis_file_key="rqa_s07e02",
                            fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.S07E02, x, y)
                        )
                    ],
@@ -73,7 +73,7 @@ def get_rqa_coding_plans(pipeline_name):
                            coding_mode=CodingModes.MULTIPLE,
                            code_scheme=CodeSchemes.S07E03,
                            coded_field="rqa_s07e03_coded",
-                           analysis_file_key="rqa_s07e03_",
+                           analysis_file_key="rqa_s07e03",
                            fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.S07E03, x, y)
                        )
                    ],
@@ -274,7 +274,7 @@ def get_follow_up_coding_plans(survey_name):
                            coding_mode=CodingModes.MULTIPLE,
                            code_scheme=CodeSchemes.SUGGESTIONS,
                            coded_field="suggestions_coded",
-                           analysis_file_key="suggestions_",
+                           analysis_file_key="suggestions",
                            fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.SUGGESTIONS, x, y)
                        )
                    ],

--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -29,11 +29,11 @@ class AnalysisFile(object):
                         assert cc.coding_mode == CodingModes.MULTIPLE
                         show_matrix_keys = []
                         for code in cc.code_scheme.codes:
-                            show_matrix_keys.append(f"{cc.analysis_file_key}{code.string_value}")
+                            show_matrix_keys.append(f"{cc.analysis_file_key}_{code.string_value}")
 
                         for label in td[cc.coded_field]:
                             code_string_value = cc.code_scheme.get_code_with_code_id(label["CodeID"]).string_value
-                            analysis_dict[f"{cc.analysis_file_key}{code_string_value}"] = Codes.MATRIX_1
+                            analysis_dict[f"{cc.analysis_file_key}_{code_string_value}"] = Codes.MATRIX_1
 
                         for key in show_matrix_keys:
                             if key not in analysis_dict:
@@ -77,7 +77,7 @@ class AnalysisFile(object):
                 else:
                     assert cc.coding_mode == CodingModes.MULTIPLE
                     for code in cc.code_scheme.codes:
-                        export_keys.append(f"{cc.analysis_file_key}{code.string_value}")
+                        export_keys.append(f"{cc.analysis_file_key}_{code.string_value}")
 
                 fold_strategies[cc.coded_field] = cc.fold_strategy
 


### PR DESCRIPTION
Adapted from an unreviewed OCHA branch.

I originally thought it would be better to include the trailing underscore in the coding plans so that we have flexibility over the separator we used. However, this turned out to be unnecessary because we've standardised to use '\_' everywhere, partly because of the need for compatibility with R. It was also slightly confusing because you need to remember which coding plans need a trailing underscore and which don't, and it means when we want to refer to the 'column' instead of each individual code (e.g. "rqa_s07e01" instead of "rqa_s07e01_about_coronavirus") you get confusing trailing underscores e.g. files named "Season distribution: rqa_s07e01_". This PR therefore assumes an '_' separator where necessary automatically.